### PR TITLE
fix: avoid passing non-strings to strcmp

### DIFF
--- a/src/Core/ResourceContext/ResourceContext.php
+++ b/src/Core/ResourceContext/ResourceContext.php
@@ -36,7 +36,7 @@ class ResourceContext implements ResourceContextInterface, ResourceRepositoryInt
         }
 
         usort($resources, function($b, $a) {
-            return strcmp($a['core.xillion.cloud/datetime'] ?? null, $b['core.xillion.cloud/datetime'] ?? null);
+            return strcmp($a['core.xillion.cloud/datetime'] ?? '', $b['core.xillion.cloud/datetime'] ?? '');
         });
 
         return $resources;


### PR DESCRIPTION
This particular call to strcmp generates many deprecation messages under PHP 8.1.